### PR TITLE
Feat/#17 카테고리 필터링 구현

### DIFF
--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,9 +1,11 @@
-import ProductList from '@/components/ProductList';
+import ProductList from '@/components/product/ProductList';
 import { getProducts } from '@/libs/api/product/product-api';
 
-const ProductsPage = async () => {
+const ProductsPage = async ({ searchParams }: { searchParams: { category?: string } }) => {
+  // URL 쿼리 파라미터에서 'category' 가져오기
+  const category = searchParams.category;
   try {
-    const products = await getProducts();
+    const products = await getProducts(category);
     return <ProductList products={products} />;
   } catch (error) {
     console.error('Error fetching products:', error);

--- a/src/components/layout/Navibar.tsx
+++ b/src/components/layout/Navibar.tsx
@@ -1,26 +1,54 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
 const Navibar = () => {
+  const router = useRouter();
+  {
+    /* 카테고리 필터링 함수 : 버튼 클릭 시 URL 업데이트*/
+  }
+  const handleFilterChange = (category: string) => {
+    const params = new URLSearchParams();
+    params.set('category', category); // 'category' 키에 값 설정
+    router.push(`/products?${params.toString()}`);
+  };
+  // UI 표시 이름이랑 DB 카테고리 ㅇ매핑
+  const CategorySuffix = {
+    '오 드 뚜왈렛': 'EDT',
+    '오 드 퍼퓸': 'EDP',
+    코롱: 'EDC',
+    헤어퍼퓸: 'HP'
+  };
   return (
     <div className="flex w-full border-b border-lightgray">
       <div className="flex w-full max-w-[1000px] h-[50px] mx-auto divide-x divide-[#d3d3d3]">
         {/* 남성용 */}
         <div className="flex flex-row flex-1 items-center px-4 gap-5 min-w-0">
-          <button className="font-semibold whitespace-nowrap text-black">For Man</button>
+          <button className="font-semibold whitespace-nowrap text-black" onClick={() => handleFilterChange('man')}>
+            For Man
+          </button>
+          {/* 하위 카테고리 버튼들: man + CategorySuffix로 필터링 */}
           <div className="flex gap-6 flex-wrap shrink min-w-0 text-l text-gray">
-            <button>오 드 뚜왈렛</button>
-            <button>오 드 퍼퓸</button>
-            <button>코롱</button>
-            <button>헤어 퍼퓸</button>
+            {Object.entries(CategorySuffix).map(([category, suffix]) => (
+              <button key={category} onClick={() => handleFilterChange(`man${suffix}`)}>
+                {category}
+              </button>
+            ))}
           </div>
         </div>
 
         {/* 여성용 */}
         <div className="flex flex-row flex-1 items-center px-4 gap-5 min-w-0">
-          <button className="font-semibold whitespace-nowrap text-black">For Woman</button>
+          <button className="font-semibold whitespace-nowrap text-black" onClick={() => handleFilterChange('woman')}>
+            For Woman
+          </button>
+          {/* 하위 카테고리 버튼들: woman + CategorySuffix로 필터링 */}
           <div className="flex gap-6 flex-wrap shrink min-w-0 text-l text-gray">
-            <button>오 드 뚜왈렛</button>
-            <button>오 드 퍼퓸</button>
-            <button>코롱</button>
-            <button>헤어 퍼퓸</button>
+            {Object.entries(CategorySuffix).map(([category, suffix]) => (
+              <button key={category} onClick={() => handleFilterChange(`woman${suffix}`)}>
+                {category}
+              </button>
+            ))}
           </div>
         </div>
       </div>

--- a/src/components/product/ProductList.tsx
+++ b/src/components/product/ProductList.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { Products } from '@/types/products';
+import Image from 'next/image';
+import Link from 'next/link';
+
+interface ProductListProps {
+  products: Products[];
+}
+
+const ProductList = ({ products }: ProductListProps) => {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        {products.map((product) => (
+          <li
+            key={product.product_id}
+            className="bg-white border rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300"
+          >
+            {/* 제품 상세 페이지 이동 링크 */}
+            <Link href={`/products/${product.product_id}`}>
+              <Image
+                src={product.product_thumbnail}
+                alt={product.product_title}
+                width={200}
+                height={48}
+                className="w-full h-48 object-cover"
+              />
+              <h2 className="text-lg font-semibold text-gray-800 truncate">{product.product_brand}</h2>
+              <p className="text-base text-gray-600 mt-1">{product.product_title}</p>
+              <p>{product.product_price.toLocaleString()}원</p>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ProductList;

--- a/src/libs/api/product/product-api.ts
+++ b/src/libs/api/product/product-api.ts
@@ -2,9 +2,20 @@ import { ProductDetails, Products } from '@/types/products';
 import { getServerClient } from '@/utils/supabase/serverClient';
 
 // 제품 리스트 불러오기
-export const getProducts = async (): Promise<Products[]> => {
+export const getProducts = async (category?: string): Promise<Products[]> => {
   const supabase = getServerClient();
-  const { data, error } = await supabase.from('products').select('*');
+  let query = supabase.from('products').select('*');
+  if (category) {
+    if (category === 'man' || category === 'woman') {
+      // "man" 또는 "woman"으로 시작하는 접두사
+      query = query.ilike('product_category', `${category}%`);
+    } else {
+      // "manEDT", "womanEDP" 등 정확한 값
+      query = query.eq('product_category', category);
+    }
+  }
+
+  const { data, error } = await query;
   if (error) {
     throw error;
   }


### PR DESCRIPTION

## ➕ 이슈 링크

- #17
  <br/>

## 🔎 작업 내용
1. Navibar.tsx
- useRouter와 URLSearchParams를 사용해 버튼 클릭 시 URL업데이트 (예: /products?category=manEDT).
- "For Man", "For Woman" 버튼과 하위 카테고리(오드뚜왈렛, 오드퍼퓸 등)를 클릭하면 해당 카테고리로 필터링.
2. products/page.tsx
- searchParams에서 category 값을 받아 서버에서 필터링된 제품 목록을 가져오기
3. product-api.ts
- getProducts 함수에서 category를 기반으로 Supabase 쿼리를 작성.
- man/woman은 부분 매칭(ilike), manEDT 등은 정확한 매칭(eq)으로 처리했습니다.
4. product/ProductList.tsx
- Link를 통해 /products/[product_id]를 연결했습니다.
  <br/>

## 리뷰 예상 시간
5분
<br/>

## 미리보기
![image](https://github.com/user-attachments/assets/a736cef1-d4df-4741-8365-6d66abc1aa6b)

<br/>
